### PR TITLE
Add wa_id field to phone object in sendContacts example

### DIFF
--- a/src/pages/en/providers/meta/uses-cases.mdx
+++ b/src/pages/en/providers/meta/uses-cases.mdx
@@ -57,7 +57,8 @@ const welcomeFlow = addKeyword<Provider, Database>(['ey','test'])
                 },
                 phones: [{
                     phone: '34000000',
-                    type: 'HOME'
+                    type: 'HOME',
+                    wa_id: '34000000' // (optional) makes META identify the number as an active wpp user
                 }]
             }
         ])


### PR DESCRIPTION
Me parece fundamental agregar la propiedad "wa_id" en el ejemplo ya que sin eso, whats app comparte el contacto como si no fuese un usuario activo. Al receptor le llega el "invite to Whats app" en el contacto si no se usa "wa_id", en lugar de poder guardarlo o enviarle un mensaje.